### PR TITLE
Improve envcheck nonce handling, logging security, and i18n

### DIFF
--- a/assets/js/sparxstar-user-environment-check.js
+++ b/assets/js/sparxstar-user-environment-check.js
@@ -32,10 +32,10 @@
     if (localStorage.getItem('envcheckBannerDismissed') === 'true') return;
     const el = document.createElement('div');
     el.id = 'envcheck-banner';
-    el.innerHTML = `
-      <p><strong>Notice:</strong> Your browser may be outdated. For the best experience, please
-      <a href="https://browsehappy.com/" target="_blank" rel="noopener">update your browser</a>.</p>
-      <button id="envcheck-dismiss" aria-label="Dismiss">&times;</button>`;
+      el.innerHTML = `
+        <p><strong>${envCheckData.i18n.notice}</strong> ${envCheckData.i18n.update_message}
+        <a href="https://browsehappy.com/" target="_blank" rel="noopener">${envCheckData.i18n.update_link}</a>.</p>
+        <button id="envcheck-dismiss" aria-label="${envCheckData.i18n.dismiss}">&times;</button>`;
     document.body.appendChild(el);
     document.getElementById('envcheck-dismiss').addEventListener('click', () => {
       el.style.display = 'none';

--- a/languages/index.php
+++ b/languages/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden

--- a/sparxstar-user-environment-check.php
+++ b/sparxstar-user-environment-check.php
@@ -20,25 +20,59 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Load plugin text domain for translations.
+ */
+function envcheck_load_textdomain() {
+    load_plugin_textdomain( 'sparxstar-user-environment-check', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+add_action( 'init', 'envcheck_load_textdomain' );
+
+/**
  * Enqueues the necessary CSS and JavaScript assets for the environment check.
  * Runs on both the front-end and the login page.
  */
 function envcheck_enqueue_assets() {
     $script_path = __DIR__ . '/assets/js/sparxstar-user-environment-check.js';
     $style_path  = __DIR__ . '/assets/css/sparxstar-user-environment-check.css';
-    $base_url    = plugin_dir_url(__FILE__);
-    
-    wp_enqueue_script('envcheck-js', $base_url . 'assets/js/sparxstar-user-environment-check.js', [], filemtime($script_path), true);
-    wp_enqueue_style('envcheck-css',  $base_url . 'assets/css/sparxstar-user-environment-check.css', [], filemtime($style_path));
+    $base_url    = plugin_dir_url( __FILE__ );
+    $cat         = apply_filters( 'envcheck_consent_category', 'statistics' );
 
+    if ( function_exists( 'wp_has_consent' ) && ! wp_has_consent( $cat ) ) {
+        return;
+    }
 
-    check_ajax_referer('envcheck_log_nonce','nonce');
-    $cat = apply_filters('envcheck_consent_category','statistics');
-    if ( function_exists('wp_has_consent') && ! wp_has_consent($cat) ) { wp_send_json_error('No consent.'); }
+    wp_enqueue_script( 'envcheck-js', $base_url . 'assets/js/sparxstar-user-environment-check.js', [], filemtime( $script_path ), true );
+    wp_enqueue_style( 'envcheck-css', $base_url . 'assets/css/sparxstar-user-environment-check.css', [], filemtime( $style_path ) );
+
+    $data = [
+        'nonce'       => wp_create_nonce( 'envcheck_log_nonce' ),
+        'ajax_url'    => admin_url( 'admin-ajax.php' ),
+        'consent_cat' => $cat,
+        'i18n'        => [
+            'notice'          => __( 'Notice:', 'sparxstar-user-environment-check' ),
+            'update_message'  => __( 'Your browser may be outdated. For the best experience, please', 'sparxstar-user-environment-check' ),
+            'update_link'     => __( 'update your browser', 'sparxstar-user-environment-check' ),
+            'dismiss'         => __( 'Dismiss', 'sparxstar-user-environment-check' ),
+        ],
+    ];
+    wp_localize_script( 'envcheck-js', 'envCheckData', $data );
 }
 add_action( 'wp_enqueue_scripts', 'envcheck_enqueue_assets' );
 add_action( 'login_enqueue_scripts', 'envcheck_enqueue_assets' );
 
+
+/**
+ * Recursively sanitize incoming data.
+ *
+ * @param mixed $value Value to sanitize.
+ * @return mixed
+ */
+function envcheck_sanitize_recursive( $value ) {
+    if ( is_array( $value ) ) {
+        return array_map( 'envcheck_sanitize_recursive', $value );
+    }
+    return is_scalar( $value ) ? sanitize_text_field( (string) $value ) : $value;
+}
 
 /**
  * Creates the AJAX endpoint to securely receive and log the diagnostic data.
@@ -48,18 +82,27 @@ function envcheck_handle_log_data() {
     // 1. Security First: Verify the nonce.
     check_ajax_referer( 'envcheck_log_nonce', 'nonce' );
 
+    // Simple rate limiting: one request per minute per IP hash.
+    $rate_key = 'envcheck_' . md5( (string) ( $_SERVER['REMOTE_ADDR'] ?? '' ) );
+    if ( get_transient( $rate_key ) ) {
+        wp_send_json_error( __( 'Too many requests. Please try again later.', 'sparxstar-user-environment-check' ) );
+    }
+    set_transient( $rate_key, 1, MINUTE_IN_SECONDS );
+
     // 2. HARDENING: Add a server-side consent gate.
     // This prevents malicious clients from posting data without consent, even if they bypass the JS check.
     $consent_category = apply_filters( 'envcheck_consent_category', 'statistics' );
     if ( function_exists( 'wp_has_consent' ) && ! wp_has_consent( $consent_category ) ) {
-        wp_send_json_error( 'Consent not provided on the server.' );
+        wp_send_json_error( __( 'Consent not provided on the server.', 'sparxstar-user-environment-check' ) );
     }
 
     // 3. Get and decode the JSON data sent from the browser.
-    $raw_data = isset( $_POST['data'] ) ? json_decode( stripslashes( $_POST['data'] ), true ) : null;
+    $raw_json = isset( $_POST['data'] ) ? wp_unslash( $_POST['data'] ) : '';
+    $raw_data = json_decode( $raw_json, true );
     if ( ! is_array( $raw_data ) ) {
-        wp_send_json_error( 'Invalid data provided.' );
+        wp_send_json_error( __( 'Invalid data provided.', 'sparxstar-user-environment-check' ) );
     }
+    $raw_data = envcheck_sanitize_recursive( $raw_data );
     
     // 4. Respect server-side privacy signals (Do Not Track / Global Privacy Control).
     $privacy_signals = $raw_data['privacy'] ?? [];
@@ -88,11 +131,17 @@ function envcheck_handle_log_data() {
         wp_mkdir_p( $log_dir );
     }
     
-    // Create a .htaccess file to block direct web access to the logs.
+    // Create a .htaccess file and index.html to block direct web access to the logs.
     $htaccess_file = $log_dir . '/.htaccess';
     if ( ! file_exists( $htaccess_file ) ) {
         $htaccess_content = "Require all denied\nDeny from all\n";
-        @file_put_contents( $htaccess_file, $htaccess_content );
+        if ( false === file_put_contents( $htaccess_file, $htaccess_content ) && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+            error_log( 'envcheck: failed to create .htaccess in log directory.' );
+        }
+    }
+    $index_file = $log_dir . '/index.html';
+    if ( ! file_exists( $index_file ) && false === file_put_contents( $index_file, '' ) && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+        error_log( 'envcheck: failed to create index.html in log directory.' );
     }
 
     // Define the rotating log file name (e.g., envcheck-2025-08-25.ndjson).
@@ -100,11 +149,11 @@ function envcheck_handle_log_data() {
     $log_line = wp_json_encode( $log_entry, JSON_INVALID_UTF8_SUBSTITUTE ) . "\n";
 
     // Append the JSON line to the log file with an exclusive lock to prevent race conditions.
-    if ( false === @file_put_contents( $log_file, $log_line, FILE_APPEND | LOCK_EX ) ) {
-        wp_send_json_error( 'Failed to write to log file.' );
+    if ( false === file_put_contents( $log_file, $log_line, FILE_APPEND | LOCK_EX ) ) {
+        wp_send_json_error( __( 'Failed to write to log file.', 'sparxstar-user-environment-check' ) );
     }
 
-    wp_send_json_success( 'Data logged.' );
+    wp_send_json_success( __( 'Data logged.', 'sparxstar-user-environment-check' ) );
 }
 add_action( 'wp_ajax_envcheck_log', 'envcheck_handle_log_data' );
 add_action( 'wp_ajax_nopriv_envcheck_log', 'envcheck_handle_log_data' );


### PR DESCRIPTION
## Summary
- localize nonce and i18n strings for envcheck assets and load text domain
- sanitize input, add simple rate limiting, and remove error-suppressed file writes
- secure log directory with .htaccess/index.html and translate JS banner text

## Testing
- `php -l sparxstar-user-environment-check.php`
- `php -l languages/index.php`
- `node --check assets/js/sparxstar-user-environment-check.js`


------
https://chatgpt.com/codex/tasks/task_e_68aff6be511c8332aa62566c13655302