### PR TITLE
Harden logging workflow and refresh utilities

### DIFF
--- a/sparxstar-user-environment-check.php
+++ b/sparxstar-user-environment-check.php
@@ -21,46 +21,92 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Primary plugin controller for SPARXSTAR User Environment Check.
+ *
+ * Coordinates asset loading, REST handling, log storage, and housekeeping tasks
+ * with awareness of multisite and multinetwork environments.
+ */
 final class Sparxstar_User_Environment_Check {
 
-	private static $instance = null;
-
-	// **MODIFIED**: This is no longer a constant, as it needs to be network-aware.
-	private $log_dir;
-	private $cron_hook;
-
-	const RETENTION_DAYS   = 30;
-	const TEXT_DOMAIN      = 'sparxstar-user-environment-check';
+	/**
+	 * Class instance used to implement the singleton pattern.
+	 *
+	 * @var ?Sparxstar_User_Environment_Check
+	 */
+	private static ?Sparxstar_User_Environment_Check $instance = null;
 
 	/**
-	 * Singleton init.
+	 * Absolute path to the directory used for NDJSON log storage.
+	 *
+	 * @var string
 	 */
-	public static function init() {
+	private string $log_dir;
+
+	/**
+	 * Hook name used when scheduling the housekeeping cron task.
+	 *
+	 * @var string
+	 */
+	private string $cron_hook;
+
+	/**
+	 * Identifier for the active network. Ensures multinetwork isolation.
+	 *
+	 * @var int
+	 */
+	private int $network_id;
+
+	/**
+	 * Number of days to retain NDJSON log files before pruning.
+	 */
+	const RETENTION_DAYS = 30;
+
+	/**
+	 * Text domain identifier used for all translation lookups.
+	 */
+	const TEXT_DOMAIN = 'sparxstar-user-environment-check';
+
+	/**
+	 * Current plugin version used for asset cache-busting.
+	 */
+	const VERSION = '2.2.4';
+
+	/**
+	 * Instantiate or retrieve the singleton instance.
+	 *
+	 * @return Sparxstar_User_Environment_Check
+	 */
+	public static function init(): Sparxstar_User_Environment_Check {
 		if ( null === self::$instance ) {
 			self::$instance = new self();
 		}
+
 		return self::$instance;
 	}
 
+	/**
+	 * Establish network-aware properties and register hooks.
+	 */
 	private function __construct() {
-		// **NEW**: Set up network-aware properties for multinetwork compatibility.
-		$network_id      = function_exists( 'get_current_network_id' ) ? get_current_network_id() : 1;
-		$this->log_dir   = WP_CONTENT_DIR . '/envcheck-logs/network-' . $network_id;
-		$this->cron_hook = 'envcheck_cron_housekeeping_' . $network_id;
+		$this->network_id = function_exists( 'get_current_network_id' ) ? (int) get_current_network_id() : 1;
+		$this->log_dir    = trailingslashit( WP_CONTENT_DIR ) . 'envcheck-logs/network-' . $this->network_id;
+		$this->cron_hook  = 'envcheck_cron_housekeeping_' . $this->network_id;
 
-		// i18n
 		add_action( 'init', [ $this, 'load_textdomain' ] );
-		// Assets
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 		add_action( 'login_enqueue_scripts', [ $this, 'enqueue_assets' ] );
-		// REST route
 		add_action( 'rest_api_init', [ $this, 'register_rest_route' ] );
-		// Housekeeping using the network-specific cron hook.
 		add_action( $this->cron_hook, [ $this, 'housekeeping' ] );
 		add_action( 'init', [ $this, 'schedule_cron_jobs' ] );
 	}
 
-	public function load_textdomain() {
+	/**
+	 * Load the plugin translation files.
+	 *
+	 * @return void
+	 */
+	public function load_textdomain(): void {
 		load_plugin_textdomain(
 			self::TEXT_DOMAIN,
 			false,
@@ -68,7 +114,12 @@ final class Sparxstar_User_Environment_Check {
 		);
 	}
 
-	public function enqueue_assets() {
+	/**
+	 * Register front-end assets, respecting consent when available.
+	 *
+	 * @return void
+	 */
+	public function enqueue_assets(): void {
 		$consent_category = apply_filters( 'envcheck_consent_category', 'statistics' );
 		if ( function_exists( 'wp_has_consent' ) && ! wp_has_consent( $consent_category ) ) {
 			return;
@@ -78,11 +129,14 @@ final class Sparxstar_User_Environment_Check {
 		$style_path  = __DIR__ . '/assets/css/sparxstar-user-environment-check.min.css';
 		$base_url    = plugin_dir_url( __FILE__ );
 
+		$script_version = file_exists( $script_path ) ? (string) filemtime( $script_path ) : self::VERSION;
+		$style_version  = file_exists( $style_path ) ? (string) filemtime( $style_path ) : self::VERSION;
+
 		wp_enqueue_script(
 			'envcheck-js',
 			$base_url . 'assets/js/sparxstar-user-environment-check.min.js',
 			[],
-			filemtime( $script_path ),
+			$script_version,
 			true
 		);
 
@@ -90,15 +144,16 @@ final class Sparxstar_User_Environment_Check {
 			'envcheck-css',
 			$base_url . 'assets/css/sparxstar-user-environment-check.min.css',
 			[],
-			filemtime( $style_path )
+			$style_version
 		);
 
 		wp_localize_script(
 			'envcheck-js',
 			'envCheckData',
 			[
-				'nonce'    => wp_create_nonce( 'wp_rest' ), // Use wp_rest nonce for REST API.
-				'ajax_url' => rest_url( 'env/v1/log' ),
+				'nonce'    => wp_create_nonce( 'wp_rest' ),
+				'ajax_url' => admin_url( 'admin-ajax.php' ),
+				'rest_url' => rest_url( 'env/v1/log' ),
 				'i18n'     => [
 					'notice'         => __( 'Notice:', self::TEXT_DOMAIN ),
 					'update_message' => __( 'Your browser may be outdated. For the best experience, please', self::TEXT_DOMAIN ),
@@ -109,27 +164,63 @@ final class Sparxstar_User_Environment_Check {
 		);
 	}
 
-	public function register_rest_route() {
+	/**
+	 * Register the REST API endpoint used for logging snapshots.
+	 *
+	 * @return void
+	 */
+	public function register_rest_route(): void {
 		register_rest_route(
 			'env/v1',
 			'/log',
 			[
 				'methods'             => 'POST',
 				'callback'            => [ $this, 'handle_log_request' ],
-				'permission_callback' => '__return_true', // Public, but we perform checks inside.
+				'permission_callback' => [ $this, 'validate_rest_request' ],
 			]
 		);
 	}
 
+	/**
+	 * Validate REST API requests before processing payloads.
+	 *
+	 * @param WP_REST_Request $request Incoming REST request.
+	 * @return bool|WP_Error True when the request is allowed or an error when blocked.
+	 */
+	public function validate_rest_request( WP_REST_Request $request ) {
+		$nonce = $request->get_header( 'X-WP-Nonce' );
+		if ( empty( $nonce ) ) {
+			return new WP_Error( 'envcheck_missing_nonce', __( 'Security token missing.', self::TEXT_DOMAIN ), [ 'status' => 403 ] );
+		}
+
+		if ( ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
+			return new WP_Error( 'envcheck_invalid_nonce', __( 'Security token is invalid or expired.', self::TEXT_DOMAIN ), [ 'status' => 403 ] );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Recursively sanitize incoming payload values.
+	 *
+	 * @param mixed $value Value to sanitize.
+	 * @return mixed Sanitized value.
+	 */
 	private function sanitize_recursive( $value ) {
 		if ( is_array( $value ) ) {
 			return array_map( [ $this, 'sanitize_recursive' ], $value );
 		}
+
 		return is_scalar( $value ) ? sanitize_text_field( (string) $value ) : $value;
 	}
 
+	/**
+	 * Handle the REST API request to persist an environment snapshot.
+	 *
+	 * @param WP_REST_Request $request Incoming REST request containing JSON diagnostics.
+	 * @return WP_REST_Response REST response indicating success or failure.
+	 */
 	public function handle_log_request( WP_REST_Request $request ) {
-		// Consent enforcement
 		$consent_category = apply_filters( 'envcheck_consent_category', 'statistics' );
 		if ( function_exists( 'wp_has_consent' ) && ! wp_has_consent( $consent_category ) ) {
 			return new WP_REST_Response( [ 'success' => false, 'data' => __( 'Consent not provided.', self::TEXT_DOMAIN ) ], 403 );
@@ -138,7 +229,6 @@ final class Sparxstar_User_Environment_Check {
 		$ip      = $request->get_ip_address();
 		$ip_hash = md5( $ip );
 
-		// Rate-limit
 		if ( ! is_user_logged_in() && get_transient( 'envcheck_rate_' . $ip_hash ) ) {
 			return new WP_REST_Response( [ 'success' => false, 'data' => __( 'Rate limit hit. Please try again later.', self::TEXT_DOMAIN ) ], 429 );
 		}
@@ -150,7 +240,6 @@ final class Sparxstar_User_Environment_Check {
 		}
 		$sanitized_data = $this->sanitize_recursive( $raw_data );
 
-		// Daily throttle with session awareness
 		$current_user_id = get_current_user_id();
 		$session_id      = $sanitized_data['sessionId'] ?? null;
 		$daily_key       = $this->get_daily_key( $current_user_id, $ip_hash, $session_id );
@@ -160,17 +249,16 @@ final class Sparxstar_User_Environment_Check {
 		}
 		set_site_transient( $daily_key, 1, DAY_IN_SECONDS );
 
-		// Collect client hints
 		$client_hints = [];
-		foreach ( [ 'Sec-CH-UA','Sec-CH-UA-Mobile','Sec-CH-UA-Platform','Sec-CH-UA-Model','Sec-CH-UA-Arch','Sec-CH-UA-Bitness','Sec-CH-UA-Full-Version' ] as $h ) {
-			$header_value = $request->get_header( $h );
+		foreach ( [ 'Sec-CH-UA', 'Sec-CH-UA-Mobile', 'Sec-CH-UA-Platform', 'Sec-CH-UA-Model', 'Sec-CH-UA-Arch', 'Sec-CH-UA-Bitness', 'Sec-CH-UA-Full-Version' ] as $hint_name ) {
+			$header_value = $request->get_header( $hint_name );
 			if ( ! empty( $header_value ) ) {
-				$client_hints[ $h ] = sanitize_text_field( $header_value );
+				$client_hints[ $hint_name ] = sanitize_text_field( $header_value );
 			}
 		}
 
-		$privacy = $sanitized_data['privacy'] ?? [];
-		$payload = $sanitized_data;
+		$privacy                 = $sanitized_data['privacy'] ?? [];
+		$payload                 = $sanitized_data;
 		$payload['client_hints'] = $client_hints;
 
 		if ( ! empty( $privacy['doNotTrack'] ) || ! empty( $privacy['gpc'] ) ) {
@@ -186,24 +274,22 @@ final class Sparxstar_User_Environment_Check {
 			];
 		}
 
-		// Allow other plugins to modify the payload before logging.
 		$payload = apply_filters( 'sparxstar_env_snapshot_payload', $payload, $request );
 
 		$entry = [
 			'timestamp_utc' => gmdate( 'c' ),
 			'user_id'       => $current_user_id,
-			'site'          => [ 'home' => home_url(), 'blog_id' => get_current_blog_id() ],
+			'site'          => [
+				'home'    => home_url(),
+				'blog_id' => get_current_blog_id(),
+			],
 			'diagnostics'   => $payload,
 		];
 
-		// **MODIFIED**: Use the network-aware log directory property.
-		if ( ! is_dir( $this->log_dir ) ) {
-			wp_mkdir_p( $this->log_dir );
+		if ( ! $this->ensure_log_directory() ) {
+			return new WP_REST_Response( [ 'success' => false, 'data' => __( 'Log directory unavailable.', self::TEXT_DOMAIN ) ], 500 );
 		}
-		@file_put_contents( $this->log_dir . '/.htaccess', "Require all denied\n", LOCK_EX );
-		@file_put_contents( $this->log_dir . '/index.php', "<?php // Silence is golden", LOCK_EX );
 
-		// **MODIFIED**: Use the network-aware log directory property.
 		$log_file = $this->log_dir . '/envcheck-' . gmdate( 'Y-m-d' ) . '.ndjson';
 		$result   = file_put_contents( $log_file, wp_json_encode( $entry ) . "\n", FILE_APPEND | LOCK_EX );
 
@@ -213,17 +299,8 @@ final class Sparxstar_User_Environment_Check {
 			return new WP_REST_Response( [ 'success' => false, 'data' => __( 'Log write failed.', self::TEXT_DOMAIN ) ], 500 );
 		}
 
-		// Cache the latest snapshot in a transient for fast access.
 		set_transient( 'sparxstar_env_last_' . $daily_key, $entry, DAY_IN_SECONDS );
 
-		/**
-		 * **NEW**: Fires after a new environment snapshot has been successfully saved.
-		 *
-		 * This allows other plugins to react to the new data in real-time.
-		 *
-		 * @since 2.2.3
-		 * @param array $entry The complete log entry that was saved.
-		 */
 		do_action( 'sparxstar_env_snapshot_saved', $entry );
 
 		return new WP_REST_Response( [ 'success' => true, 'data' => __( 'Data logged.', self::TEXT_DOMAIN ), 'snapshot_id' => $daily_key ], 200 );
@@ -237,18 +314,16 @@ final class Sparxstar_User_Environment_Check {
 	 * @return array|null The snapshot entry array, or null if not found.
 	 */
 	public function get_snapshot( $user_id = null, $session_id = null ) {
-		$user_id = is_null( $user_id ) ? get_current_user_id() : (int) $user_id;
-		$ip_hash = md5( $_SERVER['REMOTE_ADDR'] ?? '' );
-		$key     = $this->get_daily_key( $user_id, $ip_hash, $session_id );
+		$user_id   = is_null( $user_id ) ? get_current_user_id() : (int) $user_id;
+		$remote_ip = $this->get_remote_address();
+		$ip_hash   = md5( $remote_ip );
+		$key       = $this->get_daily_key( $user_id, $ip_hash, $session_id );
 
-		// 1. Try to get from the fast transient cache first.
 		$cached_snapshot = get_transient( 'sparxstar_env_last_' . $key );
 		if ( false !== $cached_snapshot && is_array( $cached_snapshot ) ) {
 			return $cached_snapshot;
 		}
 
-		// 2. If not cached, read from today's log file.
-		// **MODIFIED**: Use the network-aware log directory property.
 		$log_file = $this->log_dir . '/envcheck-' . gmdate( 'Y-m-d' ) . '.ndjson';
 		if ( ! file_exists( $log_file ) || ! is_readable( $log_file ) ) {
 			return null;
@@ -256,56 +331,109 @@ final class Sparxstar_User_Environment_Check {
 
 		$lines = file( $log_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES );
 
-		// Search backwards, as the most recent entry is likely the correct one.
 		foreach ( array_reverse( $lines ) as $line ) {
 			$entry = json_decode( $line, true );
 			if ( ! $entry || ! isset( $entry['user_id'] ) ) {
 				continue;
 			}
 
-			// Check if the user ID matches.
 			if ( (int) $entry['user_id'] === $user_id ) {
-				// If a session ID is provided, it must also match.
 				if ( ! $session_id || ( $entry['diagnostics']['sessionId'] ?? null ) === $session_id ) {
-					return $entry; // Found a match.
+					return $entry;
 				}
 			}
 		}
 
-		return null; // No snapshot found.
+		return null;
 	}
 
 	/**
 	 * Helper to consistently generate the daily transient key.
+	 *
+	 * @param int         $user_id    User identifier.
+	 * @param string      $ip_hash    Hash of the visitor IP address.
+	 * @param string|null $session_id Optional session identifier.
+	 * @return string Generated transient key scoped per network.
 	 */
 	private function get_daily_key( $user_id, $ip_hash, $session_id = null ) {
 		$key = $user_id ? 'envcheck_daily_user_' . $user_id : 'envcheck_daily_anon_' . $ip_hash;
 		if ( $session_id ) {
 			$key .= '_' . sanitize_key( $session_id );
 		}
-		return $key;
+
+		return $key . '_network_' . $this->network_id;
 	}
 
-	public function housekeeping() {
-		// **MODIFIED**: Use the network-aware log directory property.
+	/**
+	 * Delete expired NDJSON log files from the log directory.
+	 *
+	 * @return void
+	 */
+	public function housekeeping(): void {
 		if ( ! is_dir( $this->log_dir ) ) {
 			return;
 		}
-		// **MODIFIED**: Use the network-aware log directory property.
+
 		foreach ( new DirectoryIterator( $this->log_dir ) as $fileinfo ) {
 			if ( $fileinfo->isFile() && 'ndjson' === $fileinfo->getExtension() && str_starts_with( $fileinfo->getFilename(), 'envcheck-' ) ) {
 				if ( $fileinfo->getMTime() < time() - ( self::RETENTION_DAYS * DAY_IN_SECONDS ) ) {
-					@unlink( $fileinfo->getPathname() );
+					if ( ! unlink( $fileinfo->getPathname() ) ) {
+						error_log( 'SPARXSTAR EnvCheck: Unable to remove expired log file ' . $fileinfo->getPathname() );
+					}
 				}
 			}
 		}
 	}
 
-	public function schedule_cron_jobs() {
-		// **MODIFIED**: Use the network-aware cron hook property.
+	/**
+	 * Schedule daily housekeeping tasks on first run.
+	 *
+	 * @return void
+	 */
+	public function schedule_cron_jobs(): void {
 		if ( ! wp_next_scheduled( $this->cron_hook ) ) {
 			wp_schedule_event( time(), 'daily', $this->cron_hook );
 		}
+	}
+
+	/**
+	 * Create and protect the network-aware log directory.
+	 *
+	 * @return bool True when the directory is writable.
+	 */
+	private function ensure_log_directory(): bool {
+		if ( ! wp_mkdir_p( $this->log_dir ) && ! is_dir( $this->log_dir ) ) {
+			error_log( 'SPARXSTAR EnvCheck: Failed to create log directory ' . $this->log_dir );
+			return false;
+		}
+
+		$htaccess_path = $this->log_dir . '/.htaccess';
+		if ( ! file_exists( $htaccess_path ) && false === file_put_contents( $htaccess_path, "Require all denied\n", LOCK_EX ) ) {
+			error_log( 'SPARXSTAR EnvCheck: Failed to protect log directory with .htaccess.' );
+		}
+
+		$index_path = $this->log_dir . '/index.php';
+		if ( ! file_exists( $index_path ) && false === file_put_contents( $index_path, "<?php // Silence is golden" ) ) {
+			error_log( 'SPARXSTAR EnvCheck: Failed to create log directory index file.' );
+		}
+
+		return is_writable( $this->log_dir );
+	}
+
+	/**
+	 * Retrieve the visitor IP address from server variables.
+	 *
+	 * @return string IP address or empty string when unavailable.
+	 */
+	private function get_remote_address(): string {
+		$remote_addr = $_SERVER['REMOTE_ADDR'] ?? '';
+		$remote_addr = is_string( $remote_addr ) ? sanitize_text_field( wp_unslash( $remote_addr ) ) : '';
+
+		if ( filter_var( $remote_addr, FILTER_VALIDATE_IP ) ) {
+			return $remote_addr;
+		}
+
+		return '';
 	}
 }
 

--- a/src/includes/StarUserUtils.php
+++ b/src/includes/StarUserUtils.php
@@ -1,146 +1,248 @@
 <?php
 /**
+ * Utility helpers for SPARXSTAR environment diagnostics.
  *
+ * @package SparxstarUserEnvironmentCheck
  */
-// If this file is called directly, abort.
-if ((!defined('ABSPATH')) || (!defined('WPINC'))) {
+
+if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-class StarUserUtils{
-	public static function star_getIP(){
-			return $_SERVER['REMOTE_ADDR'];
+/**
+ * Collection of static helper methods for retrieving sanitized visitor metadata.
+*/
+final class StarUserUtils {
+
+	/**
+	 * Retrieve the direct remote IP address exposed by the server.
+	 *
+	 * @return string Normalized IP address or an empty string when unavailable.
+	*/
+	public static function star_getIP(): string {
+		return self::filter_ip_address( $_SERVER['REMOTE_ADDR'] ?? '' );
 	}
 
-	public static function star_getUserIP(){
-		// PHP7+
-    $clientIP = $_SERVER['HTTP_CLIENT_IP'] 
-        ?? $_SERVER["HTTP_CF_CONNECTING_IP"] # when behind cloudflare
-        ?? $_SERVER['HTTP_X_FORWARDED'] 
-        ?? $_SERVER['HTTP_X_FORWARDED_FOR'] 
-        ?? $_SERVER['HTTP_FORWARDED'] 
-        ?? $_SERVER['HTTP_FORWARDED_FOR'] 
-        ?? $_SERVER['REMOTE_ADDR'] 
-        ?? '0.0.0.0';
-    
-    // Earlier than PHP7
-    $clientIP = '0.0.0.0';
-    
-    if (isset($_SERVER['HTTP_CLIENT_IP'])) {
-        $clientIP = $_SERVER['HTTP_CLIENT_IP'];
-    } elseif (isset($_SERVER['HTTP_CF_CONNECTING_IP'])) {
-        // when behind cloudflare
-        $clientIP = $_SERVER['HTTP_CF_CONNECTING_IP']; 
-    } elseif (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-        $clientIP = $_SERVER['HTTP_X_FORWARDED_FOR'];
-    } elseif (isset($_SERVER['HTTP_X_FORWARDED'])) {
-        $clientIP = $_SERVER['HTTP_X_FORWARDED'];
-    } elseif (isset($_SERVER['HTTP_FORWARDED_FOR'])) {
-        $clientIP = $_SERVER['HTTP_FORWARDED_FOR'];
-    } elseif (isset($_SERVER['HTTP_FORWARDED'])) {
-        $clientIP = $_SERVER['HTTP_FORWARDED'];
-    } elseif (isset($_SERVER['REMOTE_ADDR'])) {
-        $clientIP = $_SERVER['REMOTE_ADDR'];
-    }
-    return $clientIP;
+	/**
+	 * Determine the most reliable client IP address using proxy-aware headers.
+	 *
+	 * @return string Normalized IP address or an empty string when it cannot be determined.
+	*/
+	public static function star_getUserIP(): string {
+		$headers = [
+		'HTTP_CLIENT_IP',
+		'HTTP_CF_CONNECTING_IP',
+		'HTTP_X_FORWARDED_FOR',
+		'HTTP_X_FORWARDED',
+		'HTTP_X_CLUSTER_CLIENT_IP',
+		'HTTP_FORWARDED_FOR',
+		'HTTP_FORWARDED',
+		'REMOTE_ADDR',
+		];
+
+		foreach ( $headers as $header ) {
+			$value = self::get_server_value( $header );
+			if ( empty( $value ) ) {
+				continue;
+			}
+
+	 // Handle comma-separated lists from X-Forwarded-For.
+			$maybe_ip = strtok( $value, ',' );
+			$maybe_ip = self::filter_ip_address( $maybe_ip );
+			if ( $maybe_ip ) {
+				return $maybe_ip;
+			}
+		}
+
+		return '';
 	}
 
-	public static function star_getUserSessionID(){
-		return session_id();
+	/**
+	 * Retrieve the active PHP session identifier when available.
+	 *
+	 * @return string Session identifier or an empty string when no session is active.
+	*/
+	public static function star_getUserSessionID(): string {
+		return PHP_SESSION_ACTIVE === session_status() ? session_id() : '';
 	}
 
-	public static function star_getUserAgent(): string{
-		return $_SERVER['HTTP_USER_AGENT'];
+	/**
+	 * Access the current user agent string with sanitization applied.
+	 *
+	 * @return string Sanitized user agent string.
+	*/
+	public static function star_getUserAgent(): string {
+		return self::get_server_value( 'HTTP_USER_AGENT' );
 	}
 
-	public static function star_getCurrentURL(): string{
-		return (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+	/**
+	 * Build the current request URL using sanitized server globals.
+	 *
+	 * @return string Normalized current URL or an empty string when incomplete data is available.
+	*/
+	public static function star_getCurrentURL(): string {
+		$host = self::get_server_value( 'HTTP_HOST' );
+		$uri  = self::get_server_value( 'REQUEST_URI' );
+
+		if ( empty( $host ) || empty( $uri ) ) {
+			return '';
+		}
+
+		$scheme = is_ssl() ? 'https://' : 'http://';
+
+		return esc_url_raw( $scheme . $host . $uri );
 	}
 
-	public static function star_getReferrerURL(): string{
-		return isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '';
+	/**
+	 * Retrieve the referring URL from the request headers.
+	 *
+	 * @return string Normalized referrer URL or an empty string when not provided.
+	*/
+	public static function star_getReferrerURL(): string {
+		$referer = self::get_server_value( 'HTTP_REFERER' );
+
+		return $referer ? esc_url_raw( $referer ) : '';
 	}
 
-	public static function star_getIPGeoLocation(): string{
-		$ip = self::star_getUserIP();
-    // TODO Replace 'YOUR_ACCESS_TOKEN' with your actual API token from a service like ipinfo.io
-    $token = 'YOUR_ACCESS_TOKEN'; 
-    $url = "https://api.ipinfo.io/lite/$ip?token=$token";
+	/**
+	 * Fetch geolocation data using an external provider hooked via WordPress filters.
+	 *
+	 * @return array Associative array of geolocation data supplied by integrations.
+	*/
+	public static function star_getIPGeoLocation(): array {
+		$ip   = self::star_getUserIP();
+		$data = apply_filters( 'sparxstar_env_geolocation_lookup', null, $ip );
 
-    $geolocationData = file_get_contents($url);
-    return json_decode($geolocationData, true); // Decode JSON response into an associative array
-}
+		return is_array( $data ) ? $data : [];
+	}
 
-public static function star_getGeoLocationData(): string {
-  $userIp = getUserIP();
-  $locationData = getUserGeolocation($userIp);
+	/**
+	 * Retrieve a specific field from the geolocation payload.
+	 *
+	 * @param string $field Optional field name to fetch (city, region, country, location).
+	 * @return string Human-readable geolocation string or a fallback message.
+	*/
+	public static function star_getGeoLocationData( string $field = '' ): string {
+		$location = self::star_getIPGeoLocation();
 
-  if (is_array($locationData) && ! is_array_empty($locationData)) {
-    switch $data
-      case "city":
-          return trim($locationData['city']);
-      case "region":
-          return trim($locationData['region']);
-      case "country":
-          return trim($locationData['country']);
-      case "location":
-          return trim($locationData['loc']);
-      default:
-  } else {
-      return "Location data unavailable.";
-  }
-}
+		if ( empty( $location ) ) {
+			return __( 'Location data unavailable.', 'sparxstar-user-environment-check' );
+		}
 
-  public static function star_getUserLanguage(string $retType='code'): string{
-    // Get the raw Accept-Language header
-    $acceptLanguage = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
-    
-    // Extract the primary language code (e.g., "en-US" or "en")
-    // This example takes the first part before a comma and before a semicolon
-    $primaryLanguage = explode(',', $acceptLanguage)[0];
-    $primaryLanguage = explode(';', $primaryLanguage)[0];
-    
-    // You might want to further process this to get just the two-letter code
-    $twoLetterCode = substr($primaryLanguage, 0, 2);
+		if ( '' === $field ) {
+			return wp_json_encode( $location );
+		}
 
-    if($retType === 'code'){
-      // returns two letter code e.g. "en"
-      return trim($twoLetterCode);
-    } else {
-      // returns locale "en_US"
-      return trim($primaryLanguage);
-    }
-  }
+		$map = [
+		'city'     => 'city',
+		'region'   => 'region',
+		'country'  => 'country',
+		'location' => 'loc',
+		];
 
-	public static function star_getUserDeviceType(){
-		$user_agent = $_SERVER['HTTP_USER_AGENT'];
-		if (preg_match('/mobile/i', $user_agent)) {
-			return 'Mobile';
-		} elseif (preg_match('/tablet/i', $user_agent)) {
+		$key = $map[ $field ] ?? null;
+		if ( $key && ! empty( $location[ $key ] ) ) {
+			return trim( (string) $location[ $key ] );
+		}
+
+		return __( 'Location data unavailable.', 'sparxstar-user-environment-check' );
+	}
+
+	/**
+	 * Determine the preferred language from the Accept-Language header.
+	 *
+	 * @param string $ret_type Either 'code' for the ISO code or 'locale' for the full locale string.
+	 * @return string Sanitized language representation.
+	*/
+	public static function star_getUserLanguage( string $ret_type = 'code' ): string {
+		$raw = self::get_server_value( 'HTTP_ACCEPT_LANGUAGE' );
+		if ( empty( $raw ) ) {
+			return '';
+		}
+
+		$primary = explode( ',', $raw )[0];
+		$primary = explode( ';', $primary )[0];
+		$primary = trim( $primary );
+
+		if ( 'code' === strtolower( $ret_type ) ) {
+			return substr( $primary, 0, 2 );
+		}
+
+		return $primary;
+	}
+
+	/**
+	 * Classify the visitor device type based on the user agent string.
+	 *
+	 * @return string One of "Mobile", "Tablet", or "Desktop".
+	*/
+	public static function star_getUserDeviceType(): string {
+		$user_agent = strtolower( self::star_getUserAgent() );
+
+		if ( preg_match( '/tablet|ipad/', $user_agent ) ) {
 			return 'Tablet';
-		} else {
-			return 'Desktop';
 		}
+
+		if ( preg_match( '/mobi|android/', $user_agent ) ) {
+			return 'Mobile';
+		}
+
+		return 'Desktop';
 	}
 
-  public static function star_getUserAgent(): string{
-    return $_SERVER['HTTP_USER_AGENT'];
-  }
+	/**
+	 * Determine the visitor operating system using a lightweight signature map.
+	 *
+	 * @return string Friendly operating system name.
+	*/
+	public static function star_getUserOS(): string {
+		$user_agent = strtolower( self::star_getUserAgent() );
+		$map        = [
+		'windows' => 'Windows',
+		'mac'     => 'Mac',
+		'linux'   => 'Linux',
+		'unix'    => 'Unix',
+		'ios'     => 'iOS',
+		'android' => 'Android',
+		];
 
-	public static function star_getUserOS(){
-		$user_agent = $_SERVER['HTTP_USER_AGENT'];
-		if (preg_match('/win/i', $user_agent)) {
-			return 'Windows';
-		} elseif (preg_match('/mac/i', $user_agent)) {
-			return 'Mac';
-		} elseif (preg_match('/linux/i', $user_agent)) {
-			return 'Linux';
-		} elseif (preg_match('/unix/i', $user_agent)) {
-			return 'Unix';
-		} else {
-			return 'Other';
+		foreach ( $map as $needle => $label ) {
+			if ( str_contains( $user_agent, $needle ) ) {
+				return $label;
+			}
 		}
+
+		return 'Other';
 	}
 
+	/**
+	 * Sanitize and validate IP address strings.
+	 *
+	 * @param string|null $value Potential IP address.
+	 * @return string Normalized IP or empty string on failure.
+	*/
+	private static function filter_ip_address( ?string $value ): string {
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
 
+		$value = trim( $value );
+		if ( str_contains( $value, ',' ) ) {
+			$value = strtok( $value, ',' );
+		}
+
+		$value = sanitize_text_field( wp_unslash( $value ) );
+
+		return filter_var( $value, FILTER_VALIDATE_IP ) ? $value : '';
+	}
+
+	/**
+	 * Retrieve a sanitized server variable by key.
+	 *
+	 * @param string $key Server array key to read.
+	 * @return string Sanitized value or empty string.
+	*/
+	private static function get_server_value( string $key ): string {
+		return isset( $_SERVER[ $key ] ) ? sanitize_text_field( wp_unslash( $_SERVER[ $key ] ) ) : '';
+	}
 }


### PR DESCRIPTION
## Summary
- convert the main controller to typed properties with a reusable version constant, add REST nonce validation, and expose the REST endpoint URL when localising assets
- harden log ingestion with stricter sanitisation, network-scoped cache keys, and guarded NDJSON directory creation and cleanup
- replace the broken StarUserUtils helper with fully documented, sanitised utility methods and a filter-based geolocation hook

## Testing
- php -l sparxstar-user-environment-check.php
- php -l src/includes/StarUserUtils.php

------
https://chatgpt.com/codex/tasks/task_e_68d0e9c7feec83329c8ba2800765f24b