### PR TITLE
Potential fix for code scanning alert no. 3: Insecure randomness

### DIFF
--- a/src/js/sparxstar-user-environment-check.js
+++ b/src/js/sparxstar-user-environment-check.js
@@ -110,8 +110,17 @@
 		sessionId = sessionStorage.getItem("envcheck_session_id");
 		if (!sessionId) {
 			// Fallback for older browsers without crypto.randomUUID
-			sessionId = crypto.randomUUID ? crypto.randomUUID() :
-				'ses_' + Date.now() + '_' + generateSecureRandomString(12);
+			if (crypto.randomUUID) {
+				sessionId = crypto.randomUUID();
+			} else {
+				const randStr = generateSecureRandomString(12);
+				if (!randStr) {
+					// Could not securely generate session ID
+					Logger.error('Session ID cannot be generated securely. Aborting.');
+					return;
+				}
+				sessionId = 'ses_' + Date.now() + '_' + randStr;
+			}
 			sessionStorage.setItem("envcheck_session_id", sessionId);
 			Logger.debug('Generated new session ID', { sessionId });
 		} else {
@@ -119,7 +128,12 @@
 		}
 	} catch (e) {
 		// Fallback if sessionStorage is not available
-		sessionId = 'ses_' + Date.now() + '_' + generateSecureRandomString(12);
+		const randStr = generateSecureRandomString(12);
+		if (!randStr) {
+			Logger.error('Session ID cannot be generated securely. Aborting.');
+			return;
+		}
+		sessionId = 'ses_' + Date.now() + '_' + randStr;
 		Logger.warn('SessionStorage unavailable, using temporary session ID', { sessionId, error: e.message });
 	}
 // Utility function to generate a cryptographically secure random string
@@ -130,8 +144,9 @@ function generateSecureRandomString(length) {
 		window.crypto.getRandomValues(array);
 		return Array.from(array).map((b) => b.toString(36)).join('');
 	} else {
-		// Fallback to Math.random (should not happen given the API check, but preserve legacy behavior)
-		return Array.from(array).map(() => Math.floor(Math.random() * 36).toString(36)).join('');
+		// Secure random generation unavailable; fail safely.
+		Logger.error('Secure random number generation unavailable. Aborting session ID generation.');
+		return null;
 	}
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Starisian-Technologies/sparxstar-user-environment-check/security/code-scanning/3](https://github.com/Starisian-Technologies/sparxstar-user-environment-check/security/code-scanning/3)

The best way to fix this problem is to prevent the use of `Math.random()` in all cases for generating session IDs (and random strings used in session IDs). In environments where `window.crypto.getRandomValues` is unavailable, the best practice is to fail securely: Either abort session ID creation entirely, warn the user, or generate a fixed unsafe token and allow only minimal (non-security-sensitive) functionality. Specifically:

- Remove the fallback to `Math.random()` in `generateSecureRandomString`.
- If browser crypto is unavailable, return `null` or an empty string, and handle this case by aborting session ID generation and optionally displaying a warning.
- Update session ID assignment logic to reject such values, log an error, and either abort or proceed with reduced functionality.
- This keeps the code safe and prevents deploying a predictable identifier.

Code changes are limited to the function `generateSecureRandomString` and usage around sessionId generation (lines 113–134 and surrounding logic) in `src/js/sparxstar-user-environment-check.js`. No external dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
