### PR TITLE
Harden admin settings output escaping

### DIFF
--- a/src/admin/SparxstarUECAdmin.php
+++ b/src/admin/SparxstarUECAdmin.php
@@ -1,6 +1,9 @@
 <?php
 /**
- * Handles the admin settings page and debug display for the plugin.
+ * Administrative settings interface for the SPARXSTAR User Environment Check plugin.
+ *
+ * This file renders the settings page, manages settings registration, and exposes
+ * diagnostic data for administrators in a secure, fully escaped manner.
  */
 declare(strict_types=1);
 
@@ -13,12 +16,24 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+/**
+ * Provides WordPress admin integrations such as settings pages and notices.
+ */
 final class SparxstarUECAdmin
 {
-
+    /**
+     * Option key used to store the GeoIP API credential.
+     */
     private const OPTION_KEY = 'sparxstar_uec_geoip_api_key';
+
+    /**
+     * Slug for the plugin's settings page.
+     */
     private const PAGE_SLUG = 'sparxstar-uec-settings';
 
+    /**
+     * Bootstraps admin-specific hooks when the current request is for the dashboard.
+     */
     public function __construct()
     {
         if (is_admin()) {
@@ -28,17 +43,23 @@ final class SparxstarUECAdmin
         }
     }
 
+    /**
+     * Registers the plugin's settings page under the WordPress "Settings" menu.
+     */
     public function add_admin_menu(): void
     {
         add_options_page(
-            'SPARXSTAR Env Check Settings',
-            'SPARXSTAR Env Check',
+            esc_html__('SPARXSTAR Env Check Settings', 'sparxstar-user-environment-check'),
+            esc_html__('SPARXSTAR Env Check', 'sparxstar-user-environment-check'),
             'manage_options',
             self::PAGE_SLUG,
             array($this, 'render_settings_page')
         );
     }
 
+    /**
+     * Registers settings, sections, and fields used by the admin page.
+     */
     public function register_settings(): void
     {
         // --- GeoIP API Key Section ---
@@ -54,40 +75,43 @@ final class SparxstarUECAdmin
 
         add_settings_section(
             'sparxstar_uec_geoip_section',
-            'GeoIP Settings',
+            esc_html__('GeoIP Settings', 'sparxstar-user-environment-check'),
             array($this, 'render_geoip_section_text'),
             self::PAGE_SLUG
         );
 
         add_settings_field(
             'sparxstar_uec_geoip_api_key_field',
-            'GeoIP API Key',
+            esc_html__('GeoIP API Key', 'sparxstar-user-environment-check'),
             array($this, 'render_api_key_field'),
             self::PAGE_SLUG,
             'sparxstar_uec_geoip_section'
         );
 
-        // --- NEW: Snapshot Viewer Section ---
+        // --- Snapshot Viewer Section ---
         add_settings_section(
             'sparxstar_uec_snapshot_viewer_section',
-            'Your Current Environment Snapshot',
-            array($this, 'render_snapshot_viewer_section'),
+            esc_html__('Your Current Environment Snapshot', 'sparxstar-user-environment-check'),
+            array($this, 'render_snapshot_viewer_section_description'),
             self::PAGE_SLUG
         );
     }
 
+    /**
+     * Outputs the main settings page markup and associated sections.
+     */
     public function render_settings_page(): void
     {
         ?>
         <div class="wrap">
-            <h1>SPARXSTAR User Environment Check Settings</h1>
+            <h1><?php esc_html_e('SPARXSTAR User Environment Check Settings', 'sparxstar-user-environment-check'); ?></h1>
 
             <!-- Settings Form -->
             <form action="options.php" method="post">
                 <?php
                 settings_fields('sparxstar_uec_options_group');
                 do_settings_sections(self::PAGE_SLUG);
-                submit_button('Save Settings');
+                submit_button(esc_html__('Save Settings', 'sparxstar-user-environment-check'));
                 ?>
             </form>
 
@@ -97,20 +121,34 @@ final class SparxstarUECAdmin
         <?php
     }
 
+    /**
+     * Provides helper text for the GeoIP settings section.
+     */
     public function render_geoip_section_text(): void
     {
-        echo '<p>Enter the API key for your chosen GeoIP service (e.g., ipinfo.io).</p>';
-    }
-
-    public function render_api_key_field(): void
-    {
-        $api_key = get_option(self::OPTION_KEY, '');
-        echo '<input type="text" name="' . esc_attr(self::OPTION_KEY) . '" value="' . esc_attr($api_key) . '" class="regular-text" />';
+        printf(
+            '<p>%s</p>',
+            esc_html__(
+                'Enter the API key for your chosen GeoIP service (e.g., ipinfo.io).',
+                'sparxstar-user-environment-check'
+            )
+        );
     }
 
     /**
-     * NEW: Renders the data dump section.
-     *
+     * Renders the GeoIP API key input field while ensuring proper escaping.
+     */
+    public function render_api_key_field(): void
+    {
+        $api_key = get_option(self::OPTION_KEY, '');
+        printf(
+            '<input type="text" name="%1$s" value="%2$s" class="regular-text" />',
+            esc_attr(self::OPTION_KEY),
+            esc_attr($api_key)
+        );
+    }
+
+    /**
      * Fetches the snapshot for the current admin user and displays it as formatted JSON.
      */
     public function render_snapshot_viewer_section(): void
@@ -124,31 +162,88 @@ final class SparxstarUECAdmin
         // Fetch the snapshot. We pass null for session_id as it's not relevant here.
         $snapshot = StarUserEnv::get_full_snapshot($current_user_id, SparxstarUECSessionManager::get_session_id());
 
-        echo '<h2>Your Current Environment Snapshot</h2>';
+        printf('<h2>%s</h2>', esc_html__('Your Current Environment Snapshot', 'sparxstar-user-environment-check'));
 
         if ($snapshot === null) {
-            echo '<p>No snapshot has been recorded for your user account yet. Please visit the front-end of the site to have your browser data logged, then return to this page.</p>';
+            printf(
+                '<p>%s</p>',
+                esc_html__(
+                    'No snapshot has been recorded for your user account yet. Please visit the front-end of the site to have your browser data logged, then return to this page.',
+                    'sparxstar-user-environment-check'
+                )
+            );
             return;
         }
 
         // Pretty-print the JSON for readability.
         $json_dump = wp_json_encode($snapshot, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        if ($json_dump === false) {
+            printf(
+                '<p class="notice notice-error"><strong>%s</strong></p>',
+                esc_html__(
+                    'Unable to display the snapshot data because encoding failed.',
+                    'sparxstar-user-environment-check'
+                )
+            );
+            return;
+        }
 
         // Display the data in a preformatted block for easy viewing.
-        echo '<p>This is the most recent data collected by the plugin for your user account. The snapshot ID is <strong>' . esc_html($snapshot['id']) . '</strong>, last updated on <strong>' . esc_html($snapshot['updated_at']) . ' UTC</strong>.</p>';
+        printf(
+            '<p>%s <strong>%s</strong>, %s <strong>%s UTC</strong>.</p>',
+            esc_html__(
+                'This is the most recent data collected by the plugin for your user account. The snapshot ID is',
+                'sparxstar-user-environment-check'
+            ),
+            isset($snapshot['id']) ? esc_html((string) $snapshot['id']) : esc_html__('unknown', 'sparxstar-user-environment-check'),
+            esc_html__(
+                'last updated on',
+                'sparxstar-user-environment-check'
+            ),
+            isset($snapshot['updated_at']) ? esc_html((string) $snapshot['updated_at']) : esc_html__('an unknown date', 'sparxstar-user-environment-check')
+        );
+
         echo '<pre style="background-color: #f1f1f1; padding: 15px; border-radius: 4px; max-height: 500px; overflow: auto;"><code>';
         echo esc_html($json_dump);
         echo '</code></pre>';
     }
 
+    /**
+     * Outputs descriptive text for the snapshot viewer section within the settings form.
+     */
+    public function render_snapshot_viewer_section_description(): void
+    {
+        printf(
+            '<p>%s</p>',
+            esc_html__(
+                'Review the most recent environment snapshot captured for your account below.',
+                'sparxstar-user-environment-check'
+            )
+        );
+    }
+
+    /**
+     * Displays admin notices when required configuration is missing.
+     */
     public function admin_notices(): void
     {
         // Check if the GeoIP API key is set
         $api_key = get_option(self::OPTION_KEY, '');
         if (empty($api_key)) {
-            echo '<div class="notice notice-warning is-dismissible">';
-            echo '<p><strong>SPARXSTAR User Environment Check:</strong> The GeoIP API key is not set. Please go to the <a href="' . esc_url(admin_url('options-general.php?page=' . self::PAGE_SLUG)) . '">settings page</a> to configure it.</p>';
-            echo '</div>';
+            printf(
+                '<div class="notice notice-warning is-dismissible"><p><strong>%1$s</strong> %2$s <a href="%3$s">%4$s</a> %5$s</p></div>',
+                esc_html__('SPARXSTAR User Environment Check:', 'sparxstar-user-environment-check'),
+                esc_html__(
+                    'The GeoIP API key is not set. Please go to the',
+                    'sparxstar-user-environment-check'
+                ),
+                esc_url(admin_url('options-general.php?page=' . self::PAGE_SLUG)),
+                esc_html__('settings page', 'sparxstar-user-environment-check'),
+                esc_html__(
+                    'to configure it.',
+                    'sparxstar-user-environment-check'
+                )
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- document the admin settings controller and its constants to satisfy repository documentation rules
- escape all rendered settings UI strings and add a failure guard when JSON encoding fails so diagnostics remain safe for administrators
- separate the snapshot section description from the viewer output to avoid duplicate rendering and keep markup outside the form

## Testing
- composer lint *(fails: vendor/bin/phpcs missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dabdb4a9ac83328f6b84725247422f